### PR TITLE
Promote all 8 stacks to Active

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,9 @@ Companion repository for the [Research Rundown](https://researchrundown.substack
 
 **Format:** Markdown, Substack
 
----
-
-### Early-Stage Stacks
-
-Scaffolded and structured, with foundations in place. These are where contributions can make the biggest difference.
-
 #### [RootStack](https://github.com/Varnasr/RootStack) — Data Layer
 
-Foundational database schemas, seed data, and queries for the ecosystem's data layer. PostgreSQL and SQLite. The shared data backbone that other stacks can connect to.
+Foundational database schemas, seed data, and queries for the ecosystem's data layer. PostgreSQL and SQLite. The shared data backbone that other stacks connect to.
 
 #### [BridgeStack](https://github.com/Varnasr/BridgeStack) — API Backend
 
@@ -91,11 +85,11 @@ FastAPI backend that bridges RootStack data to frontend applications via REST AP
 
 #### [ViewStack](https://github.com/Varnasr/ViewStack) — Frontend and Visualisation
 
-Frontend UI for visualising and interacting with OpenStacks data. Interactive dashboards, exploration tools, and data stories.
+React frontend for visualising OpenStacks data. State and scheme dashboards, indicator explorer with interactive charts, and budget trend analysis. Built with React, Recharts, and Vite.
 
 #### [PolicyStack](https://github.com/Varnasr/PolicyStack) — Policy Tracker
 
-South Asia policy tracker covering government schemes, budgets, and implementation data across development sectors. Turning policy documents into structured, queryable data.
+South Asia policy tracker with 15 flagship government schemes, 4 years of budget data, performance indicators, and analysis scripts. Turning policy documents into structured, queryable data.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -468,7 +468,7 @@
     </div>
     <div class="hero-stats">
       <div class="hero-stat"><strong>9</strong><span>Repositories</span></div>
-      <div class="hero-stat"><strong>4</strong><span>Active Stacks</span></div>
+      <div class="hero-stat"><strong>8</strong><span>Active Stacks</span></div>
       <div class="hero-stat"><strong>6+</strong><span>Languages</span></div>
       <div class="hero-stat"><strong>MIT</strong><span>Licensed</span></div>
     </div>
@@ -545,7 +545,7 @@
 
     <!-- Active -->
     <div class="tier-section">
-      <div class="tier-label">Active &mdash; real tools with code and data</div>
+      <div class="tier-label">All Stacks &mdash; real tools with code and data</div>
       <div class="stacks-grid">
 
         <a href="https://github.com/Varnasr/InsightStack" class="stack-card">
@@ -601,18 +601,10 @@
           </div>
         </a>
 
-      </div>
-    </div>
-
-    <!-- Early stage -->
-    <div class="tier-section">
-      <div class="tier-label">Early Stage &mdash; scaffolded, contributions welcome</div>
-      <div class="stacks-grid">
-
         <a href="https://github.com/Varnasr/RootStack" class="stack-card">
           <div class="card-top">
             <h3>RootStack</h3>
-            <span class="tag tag-status-early">Early Stage</span>
+            <span class="tag tag-status-active">Active</span>
           </div>
           <p class="description">Foundational database schemas, seed data, and queries for the ecosystem's data layer. The shared backbone that other stacks connect to. PostgreSQL and SQLite.</p>
           <div class="tags">
@@ -624,7 +616,7 @@
         <a href="https://github.com/Varnasr/BridgeStack" class="stack-card">
           <div class="card-top">
             <h3>BridgeStack</h3>
-            <span class="tag tag-status-early">Early Stage</span>
+            <span class="tag tag-status-active">Active</span>
           </div>
           <p class="description">FastAPI backend that bridges RootStack data to frontend applications via REST API. The plumbing that connects data to dashboards and tools.</p>
           <div class="tags">
@@ -636,7 +628,7 @@
         <a href="https://github.com/Varnasr/ViewStack" class="stack-card">
           <div class="card-top">
             <h3>ViewStack</h3>
-            <span class="tag tag-status-early">Early Stage</span>
+            <span class="tag tag-status-active">Active</span>
           </div>
           <p class="description">React frontend for visualising OpenStacks data. State and scheme dashboards, indicator explorer with interactive charts, and budget trend analysis.</p>
           <div class="tags">
@@ -649,7 +641,7 @@
         <a href="https://github.com/Varnasr/PolicyStack" class="stack-card">
           <div class="card-top">
             <h3>PolicyStack</h3>
-            <span class="tag tag-status-early">Early Stage</span>
+            <span class="tag tag-status-active">Active</span>
           </div>
           <p class="description">South Asia policy tracker &mdash; 15 flagship government schemes with 4 years of budget data, performance indicators, and analysis scripts. Turning policy documents into queryable data.</p>
           <div class="tags">


### PR DESCRIPTION
All stacks now have real code, data, and documentation. Removes the Early Stage tier and updates hero stat from 4 to 8 active stacks.