### PR TITLE
Add Experiments projects to the index; link How India Lives' own domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ If you are looking for the polished, reader-facing version of this work, start w
 | Project | What it is |
 |---|---|
 | **[PolicyDhara](https://github.com/Varnasr/PolicyDhara)** | Auto-updating tracker of Indian government policy across development sectors. A complement to Impact Mojo. |
-| **[How India Lives](https://github.com/Varnasr/how-india-lives)** | 205 state-level choropleth maps and 10 visual stories on India's diversity across demography, health, gender, economy, education, and environment. |
+| **[How India Lives](https://howindialives.impactmojo.in)** | 205 state-level choropleth maps and 10 visual stories on India's diversity across demography, health, gender, economy, education, and environment. [Source](https://github.com/Varnasr/how-india-lives). |
 | **[Some Perspective](https://github.com/Varnasr/someperspective)** | Unfunded empirical study of India's political economy, 2004–2026. Three constructed indices, full dataset, replication code, and a working paper. |
 | **[H-VSAINC](https://github.com/Varnasr/H-VSAINC)** | Hyderabad voting patterns and public infrastructure, 1999–2023, across five assembly seats. |
 | **[Bihar Parichay](https://github.com/Varnasr/BiharParichay-Project)** | Interactive bilingual resource on Bihar — society, economy, caste, migration, climate, culture. Single offline-capable HTML file. |
+| **[SDG Progress Tracker](https://sdgtracker.impactmojo.in)** | India's progress on all 17 UN Sustainable Development Goals — scores, trends, radar charts, and category breakdowns. |
+| **[India Development Indicators](https://devindicators.impactmojo.in)** | Interactive dashboard across economic, health, education, infrastructure, and environmental indicators, pulling live from the World Bank Open Data API. |
+| **[Climate TRACE India](https://climatetrace.impactmojo.in)** | Satellite-verified, facility-level greenhouse-gas emissions for India — power, manufacturing, transport, fossil fuels, agriculture, and waste, including the top-emitting coal and steel plants. |
+| **[Industry Conglomerates Tracker](https://industrygroups.impactmojo.in)** | Open geographic database of 444 major Adani and Ambani infrastructure projects, 1999–2026 — searchable and filterable, with government-support classification. |
+| **[WhoGaveTheOrder.in](https://whogavetheorder.netlify.app)** | Citizen-led accountability archive asking who authorised the use of state power against citizens. A six-state evidence grammar, a chain-of-command map, and an RTI register with a live reply-due clock. |
 
 ### Teaching and practice
 
@@ -71,6 +76,15 @@ Reusable scripts, notebooks, and templates for people doing MEL and applied rese
 
 InsightStack has a DOI: [10.5281/zenodo.15245182](https://doi.org/10.5281/zenodo.15245182).
 
+### Prototypes and research outputs
+
+Early-stage work, built in the [Experiments](https://github.com/Varnasr/Experiments) sandbox. Expect rough edges — these are shared because they are useful, not because they are finished.
+
+| Project | What it is |
+|---|---|
+| **[Court Petition Translator](https://github.com/Varnasr/Experiments/tree/main/court-translator)** | Hindi → English translation for Supreme Court and High Court petitions. Sarvam AI handles translation; Llama 3.3 corrects legal terminology (याचिकाकर्ता → Petitioner, अनुच्छेद → Article). Prototype. |
+| **[AICC Observer Grading](https://github.com/Varnasr/Experiments/tree/main/aicc_analysis)** | Methodology and scoring engine for evaluating district observers across six components of reporting readiness. Covers 592 districts and 2,413 candidate profiles. |
+
 ### Writing
 
 | Project | What it is |
@@ -83,7 +97,7 @@ InsightStack has a DOI: [10.5281/zenodo.15245182](https://doi.org/10.5281/zenodo
 | Project | What it is |
 |---|---|
 | **[CandidateDossier](https://github.com/Varnasr/CandidateDossier)** | CSV → LaTeX → PDF generator for uniform, privacy-masked candidate dossiers. |
-| **[Experiments](https://github.com/Varnasr/Experiments)** | Prototypes, proofs-of-concept, and sandbox work. Expect rough edges. |
+| **[Experiments](https://github.com/Varnasr/Experiments)** | The sandbox the projects above are built in, plus smaller tools. Where ideas live before they graduate to their own repository — or get quietly retired. |
 | **[.github](https://github.com/Varnasr/.github)** | Shared community health files — contributing guide, code of conduct, issue templates — inherited by every repo above. |
 
 ---

--- a/index.html
+++ b/index.html
@@ -506,7 +506,7 @@
     </div>
     <div class="hero-stats">
       <div class="hero-stat"><strong>20+</strong><span>Public Repositories</span></div>
-      <div class="hero-stat"><strong>4</strong><span>Live Sites</span></div>
+      <div class="hero-stat"><strong>10</strong><span>Live Sites</span></div>
       <div class="hero-stat"><strong>5</strong><span>Research Toolkits</span></div>
       <div class="hero-stat"><strong>MIT</strong><span>Licensed</span></div>
     </div>
@@ -593,13 +593,58 @@
           <div class="tags"><span class="tag tag-lang">Astro</span><span class="tag tag-lang">Open Data</span></div>
         </a>
 
-        <a href="https://github.com/Varnasr/how-india-lives" class="stack-card">
+        <a href="https://howindialives.impactmojo.in" class="stack-card">
           <div class="card-top">
             <h3>How India Lives</h3>
             <span class="tag tag-status-active">Active</span>
           </div>
           <p class="description">205 state-level choropleth maps and 10 visual stories on India&rsquo;s diversity across demography, health, gender, economy, education, and environment.</p>
           <div class="tags"><span class="tag tag-lang">HTML</span><span class="tag tag-lang">Maps</span></div>
+        </a>
+
+        <a href="https://sdgtracker.impactmojo.in" class="stack-card">
+          <div class="card-top">
+            <h3>SDG Progress Tracker</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">India&rsquo;s progress on all 17 UN Sustainable Development Goals &mdash; scores, trends, radar charts, and category breakdowns.</p>
+          <div class="tags"><span class="tag tag-lang">Chart.js</span><span class="tag tag-lang">SDGs</span></div>
+        </a>
+
+        <a href="https://devindicators.impactmojo.in" class="stack-card">
+          <div class="card-top">
+            <h3>India Development Indicators</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">Interactive dashboard across economic, health, education, infrastructure, and environmental indicators &mdash; pulling live from the World Bank Open Data API.</p>
+          <div class="tags"><span class="tag tag-lang">World Bank API</span><span class="tag tag-lang">Chart.js</span></div>
+        </a>
+
+        <a href="https://climatetrace.impactmojo.in" class="stack-card">
+          <div class="card-top">
+            <h3>Climate TRACE India</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">Satellite-verified, facility-level greenhouse-gas emissions for India &mdash; power, manufacturing, transport, fossil fuels, agriculture, and waste, including the top-emitting coal and steel plants.</p>
+          <div class="tags"><span class="tag tag-lang">Climate TRACE</span><span class="tag tag-lang">Emissions</span></div>
+        </a>
+
+        <a href="https://industrygroups.impactmojo.in" class="stack-card">
+          <div class="card-top">
+            <h3>Industry Conglomerates Tracker</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">Open geographic database of 444 major Adani and Ambani infrastructure projects, 1999&ndash;2026 &mdash; searchable and filterable, with government-support classification.</p>
+          <div class="tags"><span class="tag tag-lang">Open Data</span><span class="tag tag-lang">Mapping</span></div>
+        </a>
+
+        <a href="https://whogavetheorder.netlify.app" class="stack-card">
+          <div class="card-top">
+            <h3>WhoGaveTheOrder.in</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">Citizen-led accountability archive asking who authorised the use of state power against citizens. A six-state evidence grammar, a chain-of-command map, and an RTI register with a live reply-due clock.</p>
+          <div class="tags"><span class="tag tag-lang">Evidence Archive</span><span class="tag tag-lang">RTI</span></div>
         </a>
 
         <a href="https://github.com/Varnasr/someperspective" class="stack-card">
@@ -770,12 +815,30 @@
           <div class="tags"><span class="tag tag-lang">LaTeX</span><span class="tag tag-lang">Netlify</span></div>
         </a>
 
+        <a href="https://github.com/Varnasr/Experiments/tree/main/court-translator" class="stack-card">
+          <div class="card-top">
+            <h3>Court Petition Translator</h3>
+            <span class="tag tag-status-early">Prototype</span>
+          </div>
+          <p class="description">Hindi &rarr; English translation for Supreme Court and High Court petitions. Sarvam AI handles translation; Llama 3.3 corrects legal terminology.</p>
+          <div class="tags"><span class="tag tag-lang">Sarvam AI</span><span class="tag tag-lang">Groq</span></div>
+        </a>
+
+        <a href="https://github.com/Varnasr/Experiments/tree/main/aicc_analysis" class="stack-card">
+          <div class="card-top">
+            <h3>AICC Observer Grading</h3>
+            <span class="tag tag-status-early">Prototype</span>
+          </div>
+          <p class="description">Methodology and scoring engine for evaluating district observers across six components of reporting readiness. 592 districts, 2,413 candidate profiles.</p>
+          <div class="tags"><span class="tag tag-lang">Python</span><span class="tag tag-lang">CSV</span></div>
+        </a>
+
         <a href="https://github.com/Varnasr/Experiments" class="stack-card">
           <div class="card-top">
             <h3>Experiments</h3>
             <span class="tag tag-status-stable">Sandbox</span>
           </div>
-          <p class="description">Prototypes, proofs-of-concept, and sandbox work. Expect rough edges &mdash; nothing here is a finished thing.</p>
+          <p class="description">The sandbox the prototypes above are built in, plus smaller tools. Where ideas live before they graduate to their own repository &mdash; or get quietly retired.</p>
           <div class="tags"><span class="tag tag-lang">Mixed</span></div>
         </a>
 


### PR DESCRIPTION
## What does this PR do?

Six projects living in the [Experiments](https://github.com/Varnasr/Experiments) sandbox were never surfaced on openstacks.dev, despite four of them running on their own `impactmojo.in` subdomains. The index is meant to be a front door; these were sitting behind it.

**Added to Data and policy** — all verified live (HTTP 200):

| Project | Live at |
|---|---|
| SDG Progress Tracker | `sdgtracker.impactmojo.in` |
| India Development Indicators | `devindicators.impactmojo.in` |
| Climate TRACE India | `climatetrace.impactmojo.in` |
| Industry Conglomerates Tracker | `industrygroups.impactmojo.in` |
| WhoGaveTheOrder.in | `whogavetheorder.netlify.app` |

**New "Prototypes and research outputs" section** — for work that is useful but unfinished, so it isn't presented as equivalent to the maintained tools: the Court Petition Translator (Sarvam AI + Llama 3.3) and the AICC Observer Grading methodology. Both carry a `Prototype` label on the landing page.

**Also fixed:** How India Lives now links `howindialives.impactmojo.in` rather than only its repository — the domain existed and the index wasn't using it. The Experiments row now describes what the sandbox actually holds, and the hero count is corrected from 4 live sites to 10.

**Deliberately not listed:** Kundendu's Learn & Play and Nilaya E-Pothi (personal, not development research) and the Chamber Petition (a private project).

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [x] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [x] Documentation update

## Checklist

- [x] Tested on desktop browser — rendered at 1280×900, 26 project cards, no horizontal overflow
- [x] Tested on mobile browser — previously verified at 390×844; layout uses the same auto-fit grid
- [x] No console errors — zero page errors
- [x] Links are working — all six destinations verified 200; zero broken relative links; HTML validated with no unclosed or mismatched tags

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkaofZXuUTAovNkveXEDNe)_