### PR TITLE
Correct ImpactLex status: graduated, not retired; drop AICC listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ If you are looking for the polished, reader-facing version of this work, start w
 | **[DevData Practice](https://github.com/Varnasr/devdata-practice)** | Realistic practice datasets — 10 generators, 350k+ rows. |
 | **[DevEconomics Toolkit](https://github.com/Varnasr/deveconomics-toolkit)** | 11 interactive Shiny apps for impact evaluation, poverty analysis, and program design. |
 | **[The Real Middle](https://github.com/Varnasr/The-Real-Middle)** | Interactive game revealing where you actually stand in India's income distribution. |
+| **[ImpactLex](https://www.impactmojo.in/impactlex/)** | Development-sector glossary and companion to Impact Mojo — 390+ terms merged from 20 course lexicons, with 5 case studies, 10 worked formulae, and cross-references to where each term is taught. Offline-capable PWA. |
 
 ### Research toolkits — the OpenStacks
 
@@ -83,7 +84,6 @@ Early-stage work, built in the [Experiments](https://github.com/Varnasr/Experime
 | Project | What it is |
 |---|---|
 | **[Court Petition Translator](https://github.com/Varnasr/Experiments/tree/main/court-translator)** | Hindi → English translation for Supreme Court and High Court petitions. Sarvam AI handles translation; Llama 3.3 corrects legal terminology (याचिकाकर्ता → Petitioner, अनुच्छेद → Article). Prototype. |
-| **[AICC Observer Grading](https://github.com/Varnasr/Experiments/tree/main/aicc_analysis)** | Methodology and scoring engine for evaluating district observers across six components of reporting readiness. Covers 592 districts and 2,413 candidate profiles. |
 
 ### Writing
 
@@ -111,7 +111,7 @@ These are archived and read-only. The code stays public and browsable; nothing h
 | **[RootStack](https://github.com/Varnasr/RootStack)** | SQLite/PostgreSQL schemas and seed data for the shared data layer |
 | **[BridgeStack](https://github.com/Varnasr/BridgeStack)** | FastAPI backend serving RootStack to frontends |
 | **[ViewStack](https://github.com/Varnasr/ViewStack)** | React dashboard for exploring the data |
-| **[ImpactLex](https://github.com/Varnasr/ImpactLex)** | Earlier lexicon project |
+**Not retired — graduated.** [ImpactLex](https://www.impactmojo.in/impactlex/) moved into Impact Mojo rather than winding down, and is listed under Teaching and practice above. Its [old repository](https://github.com/Varnasr/ImpactLex) is archived for citation continuity only; the living version is at [impactmojo.in/impactlex](https://www.impactmojo.in/impactlex/).
 
 Four further stacks — ClimateStack, EduStack, SocialStack, InfraStack — were on a published roadmap and were never started. That roadmap has been withdrawn rather than left standing as a promise. The needs behind them are better served by [How India Lives](https://github.com/Varnasr/how-india-lives), [PolicyDhara](https://github.com/Varnasr/PolicyDhara), and [JanVayu](https://www.janvayu.in).
 

--- a/index.html
+++ b/index.html
@@ -727,6 +727,15 @@
           <div class="tags"><span class="tag tag-lang">React</span></div>
         </a>
 
+        <a href="https://www.impactmojo.in/impactlex/" class="stack-card">
+          <div class="card-top">
+            <h3>ImpactLex</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">Development-sector glossary and companion to Impact Mojo &mdash; 390+ terms merged from 20 course lexicons, with 5 case studies, 10 worked formulae, and cross-references to where each term is taught. Offline-capable PWA.</p>
+          <div class="tags"><span class="tag tag-lang">Glossary</span><span class="tag tag-lang">PWA</span></div>
+        </a>
+
       </div>
     </div>
 
@@ -824,15 +833,6 @@
           <div class="tags"><span class="tag tag-lang">Sarvam AI</span><span class="tag tag-lang">Groq</span></div>
         </a>
 
-        <a href="https://github.com/Varnasr/Experiments/tree/main/aicc_analysis" class="stack-card">
-          <div class="card-top">
-            <h3>AICC Observer Grading</h3>
-            <span class="tag tag-status-early">Prototype</span>
-          </div>
-          <p class="description">Methodology and scoring engine for evaluating district observers across six components of reporting readiness. 592 districts, 2,413 candidate profiles.</p>
-          <div class="tags"><span class="tag tag-lang">Python</span><span class="tag tag-lang">CSV</span></div>
-        </a>
-
         <a href="https://github.com/Varnasr/Experiments" class="stack-card">
           <div class="card-top">
             <h3>Experiments</h3>
@@ -861,13 +861,10 @@
           <h4>ViewStack</h4>
           <p>React dashboard for exploring the data</p>
         </div>
-        <div class="planned-card">
-          <h4>ImpactLex</h4>
-          <p>An earlier lexicon project</p>
-        </div>
       </div>
       <div class="notice">
         <p>These three formed a database &rarr; API &rarr; dashboard pipeline. It was the most expensive part of this project to maintain and the least used &mdash; and the research toolkits never depended on it. Nothing has been deleted: the code stays public, forkable, and citable.</p>
+        <p><strong>ImpactLex is not on this list.</strong> Its old repository is archived, but the project graduated into <a href="https://www.impactmojo.in/impactlex/">Impact Mojo</a> rather than winding down &mdash; it is listed under Teaching and practice above. An archived repository and a finished project are not the same thing.</p>
         <p>Four further stacks &mdash; ClimateStack, EduStack, SocialStack, and InfraStack &mdash; sat on a published roadmap for a year without a line of code written. That roadmap has been withdrawn rather than left standing as a promise to readers. The needs behind it are better served by How India Lives, PolicyDhara, and JanVayu.</p>
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?

**Fixes a wrong status.** ImpactLex was filed under *Retired* because its repository is archived. That conflated an archived repo with a finished project — and here the conflation was plainly wrong. The archived README says so itself: *"This repository has moved."*

The project is alive at [impactmojo.in/impactlex](https://www.impactmojo.in/impactlex/) (verified 200), with 390+ terms merged from 20 course lexicons, 5 case studies, 10 worked formulae, an InstantDB backend, and an offline-capable PWA. It's now listed under **Teaching and practice**, and the Retired section states explicitly that an archived repository and a finished project are not the same thing.

RootStack, BridgeStack, and ViewStack are unaffected — those are genuinely wound down.

**Also:** removed the AICC Observer Grading listing from the README and landing page.

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [x] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [x] Documentation update

## Checklist

- [x] Tested on desktop browser — 26 cards, no horizontal overflow
- [x] Tested on mobile browser — same auto-fit grid, previously verified
- [x] No console errors — zero page errors
- [x] Links are working — impactmojo.in/impactlex verified 200; zero broken relative links; HTML validated with no unclosed or mismatched tags

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkaofZXuUTAovNkveXEDNe)_