### PR TITLE
Link live sites rather than repos; add the Bihar Electoral Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ If you are looking for the polished, reader-facing version of this work, start w
 |---|---|
 | **[PolicyDhara](https://github.com/Varnasr/PolicyDhara)** | Auto-updating tracker of Indian government policy across development sectors. A complement to Impact Mojo. |
 | **[How India Lives](https://howindialives.impactmojo.in)** | 205 state-level choropleth maps and 10 visual stories on India's diversity across demography, health, gender, economy, education, and environment. [Source](https://github.com/Varnasr/how-india-lives). |
-| **[Some Perspective](https://github.com/Varnasr/someperspective)** | Unfunded empirical study of India's political economy, 2004–2026. Three constructed indices, full dataset, replication code, and a working paper. |
+| **[Some Perspective](https://someperspective.info)** | Unfunded empirical study of India's political economy, 2004–2026. Three constructed indices, full dataset, replication code, and a working paper. |
 | **[H-VSAINC](https://github.com/Varnasr/H-VSAINC)** | Hyderabad voting patterns and public infrastructure, 1999–2023, across five assembly seats. |
 | **[Bihar Parichay](https://github.com/Varnasr/BiharParichay-Project)** | Interactive bilingual resource on Bihar — society, economy, caste, migration, climate, culture. Single offline-capable HTML file. |
+| **[Bihar Electoral Dashboard](https://forindia.netlify.app)** | Analysis of Bihar electoral roll anomalies — voter deletion patterns, demographic shifts, and election data integrity. |
 | **[SDG Progress Tracker](https://sdgtracker.impactmojo.in)** | India's progress on all 17 UN Sustainable Development Goals — scores, trends, radar charts, and category breakdowns. |
 | **[India Development Indicators](https://devindicators.impactmojo.in)** | Interactive dashboard across economic, health, education, infrastructure, and environmental indicators, pulling live from the World Bank Open Data API. |
 | **[Climate TRACE India](https://climatetrace.impactmojo.in)** | Satellite-verified, facility-level greenhouse-gas emissions for India — power, manufacturing, transport, fossil fuels, agriculture, and waste, including the top-emitting coal and steel plants. |
@@ -57,7 +58,7 @@ If you are looking for the polished, reader-facing version of this work, start w
 | Project | What it is |
 |---|---|
 | **[Dev Case Studies](https://github.com/Varnasr/dev-case-studies)** | 200 real development case studies from 117 countries — searchable, filterable, fully cited. |
-| **[Development Discourses](https://github.com/Varnasr/development-discourses)** | Curated open-access library of 500+ papers, books, and grey literature for South Asian practitioners. |
+| **[Development Discourses](https://varnasr.github.io/development-discourses/)** | Curated open-access library of 500+ papers, books, and grey literature for South Asian practitioners. |
 | **[DevData Practice](https://github.com/Varnasr/devdata-practice)** | Realistic practice datasets — 10 generators, 350k+ rows. |
 | **[DevEconomics Toolkit](https://github.com/Varnasr/deveconomics-toolkit)** | 11 interactive Shiny apps for impact evaluation, poverty analysis, and program design. |
 | **[The Real Middle](https://github.com/Varnasr/The-Real-Middle)** | Interactive game revealing where you actually stand in India's income distribution. |
@@ -90,7 +91,7 @@ Early-stage work, built in the [Experiments](https://github.com/Varnasr/Experime
 | Project | What it is |
 |---|---|
 | **[The Measurement Trap](https://github.com/Varnasr/the-measurement-trap)** | Companion site for *The Measurement Trap: India's Quest for Social Progress Through Eight Decades* (Routledge, forthcoming). Live at [whatcounts.in](https://whatcounts.in/). |
-| **[The Very Last Superhero](https://github.com/Varnasr/theverylastsuperhero)** | Illustrated speculative fiction set in a climate-collapsed India. |
+| **[The Very Last Superhero](https://postheroic.world)** | Illustrated speculative fiction set in a climate-collapsed India. |
 
 ### Utilities
 

--- a/index.html
+++ b/index.html
@@ -602,6 +602,15 @@
           <div class="tags"><span class="tag tag-lang">HTML</span><span class="tag tag-lang">Maps</span></div>
         </a>
 
+        <a href="https://forindia.netlify.app" class="stack-card">
+          <div class="card-top">
+            <h3>Bihar Electoral Dashboard</h3>
+            <span class="tag tag-status-active">Active</span>
+          </div>
+          <p class="description">Analysis of Bihar electoral roll anomalies &mdash; voter deletion patterns, demographic shifts, and election data integrity.</p>
+          <div class="tags"><span class="tag tag-lang">Elections</span><span class="tag tag-lang">Data Integrity</span></div>
+        </a>
+
         <a href="https://sdgtracker.impactmojo.in" class="stack-card">
           <div class="card-top">
             <h3>SDG Progress Tracker</h3>
@@ -647,7 +656,7 @@
           <div class="tags"><span class="tag tag-lang">Evidence Archive</span><span class="tag tag-lang">RTI</span></div>
         </a>
 
-        <a href="https://github.com/Varnasr/someperspective" class="stack-card">
+        <a href="https://someperspective.info" class="stack-card">
           <div class="card-top">
             <h3>Some Perspective</h3>
             <span class="tag tag-status-stable">Stable</span>
@@ -691,7 +700,7 @@
           <div class="tags"><span class="tag tag-lang">JavaScript</span></div>
         </a>
 
-        <a href="https://github.com/Varnasr/development-discourses" class="stack-card">
+        <a href="https://varnasr.github.io/development-discourses/" class="stack-card">
           <div class="card-top">
             <h3>Development Discourses</h3>
             <span class="tag tag-status-active">Active</span>
@@ -806,7 +815,7 @@
           <div class="tags"><span class="tag tag-lang">HTML</span></div>
         </a>
 
-        <a href="https://github.com/Varnasr/theverylastsuperhero" class="stack-card">
+        <a href="https://postheroic.world" class="stack-card">
           <div class="card-top">
             <h3>The Very Last Superhero</h3>
             <span class="tag tag-status-active">Active</span>


### PR DESCRIPTION
## What does this PR do?

Comparing openstacks.dev against `varnasr-experiments.netlify.app` showed the index sending readers to **source code in cases where a published site exists**. Someone who wants the thing was being handed the code for it.

Retargeted to their live sites, all verified 200:

| Project | Was | Now |
|---|---|---|
| Some Perspective | GitHub repo | `someperspective.info` |
| Development Discourses | GitHub repo | `varnasr.github.io/development-discourses/` |
| The Very Last Superhero | GitHub repo | `postheroic.world` |

**The Real Middle was deliberately left pointing at its repository.** The `therealmiddle.netlify.app` link carried on the Experiments page returns **404**, and no other live URL exists (`therealmiddle.impactmojo.in` and the GitHub Pages path both fail), so the repo is the only working destination.

**Added the Bihar Electoral Dashboard** (`forindia.netlify.app`) — analysis of Bihar electoral roll anomalies, voter deletion patterns and election data integrity. It was listed on the Experiments page and missing from this index entirely.

## Type of change

- [x] Bug fix (broken link, layout, JS error)
- [x] New content
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [x] Documentation update

## Checklist

- [x] Tested on desktop browser — 27 cards, no horizontal overflow
- [x] Tested on mobile browser — same auto-fit grid, previously verified
- [x] No console errors
- [x] Links are working — all four new targets verified 200; the one 404 found was excluded rather than shipped; HTML validated with no unclosed or mismatched tags

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkaofZXuUTAovNkveXEDNe)_