### PR TITLE
Plain wording on the Hyderabad card

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,7 +670,7 @@
             <h3>Hyderabad Electoral Analysis</h3>
             <span class="tag tag-status-active">Active</span>
           </div>
-          <p class="description">Five old-city seats, one winner since 1999 &mdash; and still the poorest part of Hyderabad. Ward-level census data shows the gap is in work and income, not services or slums: water and drainage are at full parity, but a third fewer people have jobs. The only gaps that closed since 2011 were closed by national schemes. Includes a run of the standard causal test, reported honestly as unanswerable from public data.</p>
+          <p class="description">Five old-city seats, one winner since 1999 &mdash; and still the poorest part of Hyderabad. Ward-level census data shows the gap is in work and income, not services or slums: water and drainage are at full parity, but a third fewer people have jobs. The only gaps that closed since 2011 were closed by national schemes. Includes a run of the standard causal test, which cannot answer either way from public data.</p>
           <div class="tags"><span class="tag tag-lang">Elections</span><span class="tag tag-lang">Census</span><span class="tag tag-lang">Data</span></div>
         </a>
 


### PR DESCRIPTION
## What does this PR do?

One-line wording fix on the Hyderabad Electoral Analysis card: "reported honestly as unanswerable" was the card grading the work; it now reads *"the standard causal test, which cannot answer either way from public data."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkaofZXuUTAovNkveXEDNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkaofZXuUTAovNkveXEDNe)_