### PR TITLE
Update: plainer copy on the landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" type="image/x-icon" href="favicon_openstacks.ico">
   <link rel="icon" type="image/png" href="favicon_openstacks.png">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="An index of open-source work on development research, data and policy by Dr. Varna Sri Raman: data explorers, teaching material, research toolkits and utilities for India and South Asia, each with a status label that means something.">
+  <meta name="description" content="An index of open-source repositories on development research, data and policy in India and South Asia, by Dr. Varna Sri Raman. Data explorers, teaching material, research toolkits and utilities, each with a status label.">
   <meta property="og:title" content="OpenStacks for Change">
   <meta property="og:description" content="An index of open-source work on development research, data and policy across health, education, gender and climate.">
   <meta property="og:type" content="website">
@@ -208,26 +208,26 @@
 
 <div class="hero" id="top"><div class="wrap">
   <div>
-    <div class="kicker"><i></i> An index, not a product</div>
-    <h1>Open-source work on how India is <em>measured</em>, governed and lived in.</h1>
-    <p class="lede">The repositories behind two decades of development research, data and policy work in India and South Asia: data explorers, teaching material, research toolkits and small utilities. Every entry carries a status label with a stated commitment behind it, so you know what to expect before you clone.</p>
-    <div class="cta"><a class="btn solid" href="#index">Browse the index</a><a class="btn" href="#start">Start with the reader-facing sites</a></div>
+    <div class="kicker"><i></i> Index of repositories</div>
+    <h1>Open-source work on development research, data and policy.</h1>
+    <p class="lede">Twenty-six public repositories by Varna Sri Raman, most of them about India, grouped by what they are for: data explorers and trackers, teaching material, research toolkits, and a few utilities. Each one has a status label. The labels are defined further down and in the <a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/MAINTENANCE.md">maintenance policy</a>.</p>
+    <div class="cta"><a class="btn solid" href="#index">See the repositories</a><a class="btn" href="#start">Reader-facing sites</a></div>
   </div>
-  <aside class="card-index" aria-label="Index at a glance">
-    <h2>At a glance</h2>
+  <aside class="card-index" aria-label="Counts on this page">
+    <h2>On this page</h2>
     <div class="stats">
-      <div class="stat"><b id="nProj">0</b><span>projects indexed</span></div>
+      <div class="stat"><b id="nProj">0</b><span>repositories</span></div>
       <div class="stat"><b id="nLive">0</b><span>with a live site</span></div>
-      <div class="stat t"><b id="nActive">0</b><span>active, answered in days</span></div>
-      <div class="stat"><b id="nStable">0</b><span>stable, kept working</span></div>
+      <div class="stat t"><b id="nActive">0</b><span>active</span></div>
+      <div class="stat"><b id="nStable">0</b><span>stable</span></div>
     </div>
-    <div class="foot"><span>3 retired, kept public</span><span>MIT licence</span><span>Delhi, India</span></div>
+    <div class="foot"><span>3 retired</span><span>MIT licence</span><span>Delhi</span></div>
   </aside>
 </div></div>
 
 <!-- Start here -->
 <section id="start"><div class="wrap">
-  <div class="sec-head"><div class="n"><i></i>01</div><div><h2>Start here if you want the reader's version</h2><p>Three sites built on the work below. They are the finished face of it; the index is the workshop.</p></div></div>
+  <div class="sec-head"><div class="n"><i></i>01</div><div><h2>Start here</h2><p>Three sites built on the repositories below. If you want to use the work rather than read the code, go to these.</p></div></div>
   <div class="tiles">
     <a class="tile" href="https://www.impactmojo.in"><span class="go">↗</span><div class="dom">impactmojo.in</div><h3>Impact Mojo</h3><p>Teaching and practice platform for development economics and social research: courses, case studies and open teaching material.</p></a>
     <a class="tile" href="https://www.janvayu.in"><span class="go">↗</span><div class="dom">janvayu.in</div><h3>JanVayu जनवायु</h3><p>A citizen-led national archive of India's air quality crisis: data, stories and sensor readings.</p></a>
@@ -237,25 +237,25 @@
 
 <!-- What this is -->
 <section id="status"><div class="wrap">
-  <div class="sec-head"><div class="n"><i></i>02</div><div><h2>What this is, and what the labels mean</h2></div></div>
+  <div class="sec-head"><div class="n"><i></i>02</div><div><h2>What this is</h2></div></div>
   <div class="two">
     <div class="prose">
-      <p><strong>This site is an index.</strong> It points to the open-source repositories behind work in development economics, evaluation and public-interest data, and it says plainly which of them are being worked on, which merely work, and which have been put away.</p>
-      <p>It began in 2025 as the hub for a family of eight interlocking "stacks". Some of those turned out to be useful and are still here, still working. Others were scaffolding for an ecosystem that never needed to exist, and have been retired. Rather than leave that ambiguous, every repository carries one of the labels on the right, and the <a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/MAINTENANCE.md">maintenance policy</a> says what each one commits to.</p>
-      <p>Everything is MIT-licensed code unless a repository says otherwise; some written content carries Creative Commons terms. Each project is self-contained: clone the one you need, read its README, run it. There is no ecosystem to install.</p>
+      <p><strong>This site is an index.</strong> It holds no code or data of its own; every link goes to a repository on GitHub or to a live site built from one.</p>
+      <p>It started in 2025 as the home page for eight related "stacks". Five of them are in use and are listed under research toolkits. The other three (RootStack, BridgeStack and ViewStack) were a database, an API and a dashboard that the toolkits did not need; they are archived and listed at the bottom of the page.</p>
+      <p>Every repository has one of the four labels on the right. The <a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/MAINTENANCE.md">maintenance policy</a> says what each label commits the maintainer to. Code is MIT-licensed unless a repository says otherwise; some written material is under Creative Commons. Each repository stands on its own, with its own README and no shared dependency.</p>
     </div>
     <div class="legend" role="list">
-      <div class="row" role="listitem"><b><i class="dot active"></i>Active</b><p>Under development. Issues and pull requests get a response within days. CI runs and is expected to pass; dependencies are kept current.</p></div>
-      <div class="row" role="listitem"><b><i class="dot stable"></i>Stable</b><p>Works and is correct, and is not being developed. Bug reports welcome; feature requests likely declined; replies take weeks. Dependencies are pinned and left alone.</p></div>
-      <div class="row" role="listitem"><b><i class="dot proto"></i>Prototype</b><p>Shared because it is useful, not because it is finished. Expect rough edges. Lives in the Experiments sandbox until it graduates or is retired.</p></div>
-      <div class="row" role="listitem"><b><i class="dot retired"></i>Retired</b><p>Archived on GitHub, read-only. Kept public so links, citations and forks keep working. Never deleted.</p></div>
+      <div class="row" role="listitem"><b><i class="dot active"></i>Active</b><p>Being worked on. Issues and pull requests get a reply within days.</p></div>
+      <div class="row" role="listitem"><b><i class="dot stable"></i>Stable</b><p>Works as described and is not being developed. Bug reports are welcome and may wait weeks for a reply. New features are unlikely.</p></div>
+      <div class="row" role="listitem"><b><i class="dot proto"></i>Prototype</b><p>Unfinished, and shared as it is. Lives in the Experiments repository until it gets a repository of its own or is dropped.</p></div>
+      <div class="row" role="listitem"><b><i class="dot retired"></i>Retired</b><p>Archived on GitHub and read-only. Kept public so that links, citations and forks continue to work.</p></div>
     </div>
   </div>
 </div></section>
 
 <!-- Index -->
 <section id="index"><div class="wrap">
-  <div class="sec-head"><div class="n"><i></i>03</div><div><h2>The index</h2><p>Grouped by what each project is for. Filter by group or status, or search titles, descriptions and tags.</p></div></div>
+  <div class="sec-head"><div class="n"><i></i>03</div><div><h2>Repositories</h2><p>Grouped by purpose. Filter by group or status, or search.</p></div></div>
   <div class="toolbar">
     <input type="search" id="q" placeholder="Search the index" aria-label="Search the index">
     <div class="chips" id="groups" role="group" aria-label="Filter by group"><button class="chip on" data-g="">All</button><button class="chip" data-g="data">Data and policy</button><button class="chip" data-g="teach">Teaching and practice</button><button class="chip" data-g="stack">Research toolkits</button><button class="chip" data-g="write">Writing and utilities</button></div>
@@ -292,7 +292,7 @@
   </div>
 
   <div class="group" data-g="stack">
-    <div class="group-h"><h3>Research toolkits</h3><span>the OpenStacks themselves</span></div>
+    <div class="group-h"><h3>Research toolkits</h3><span>the five stacks</span></div>
     <div class="list">
       <a class="entry" data-s="stable" href="https://github.com/Varnasr/InsightStack"><span class="no"></span><div><h4>InsightStack</h4><span class="st"><i class="dot stable"></i>stable</span><span class="url">github.com/Varnasr/InsightStack</span></div><div><p>The largest of the set. MEL calculators, visual frameworks, research documentation templates and a full econometrics module (DiD, PSM, IV/2SLS, RDD, sensitivity analysis). Has a DOI: 10.5281/zenodo.15245182.</p><div class="tags"><span class="tag">Stata</span><span class="tag">Python</span><span class="tag">R</span><span class="tag">Observable</span></div></div><span class="arrow">→</span></a>
       <a class="entry" data-s="stable" href="https://github.com/Varnasr/FieldStack"><span class="no"></span><div><h4>FieldStack</h4><span class="st"><i class="dot stable"></i>stable</span><span class="url">github.com/Varnasr/FieldStack</span></div><div><p>The applied fieldwork lifecycle: survey design, sample size, sampling weights, complex survey analysis, cost-effectiveness, qualitative coding and batch Quarto reporting.</p><div class="tags"><span class="tag">R</span><span class="tag">Quarto</span><span class="tag">KoboToolbox</span></div></div><span class="arrow">→</span></a>
@@ -303,13 +303,13 @@
   </div>
 
   <div class="group" data-g="write">
-    <div class="group-h"><h3>Writing and utilities</h3><span>books, fiction, small tools, the sandbox</span></div>
+    <div class="group-h"><h3>Writing and utilities</h3><span>books, fiction, small tools</span></div>
     <div class="list">
       <a class="entry" data-s="active" href="https://github.com/Varnasr/the-measurement-trap"><span class="no"></span><div><h4>The Measurement Trap</h4><span class="st"><i class="dot active"></i>active</span><span class="url">github.com/Varnasr/the-measurement-trap</span></div><div><p>Companion site for the forthcoming Routledge book on India's quest for social progress through eight decades of measurement.</p><div class="tags"><span class="tag">HTML</span></div></div><span class="arrow">→</span></a>
       <a class="entry" data-s="active" data-live="1" href="https://postheroic.world"><span class="no"></span><div><h4>The Very Last Superhero</h4><span class="st"><i class="dot active"></i>active</span><span class="url">postheroic.world</span></div><div><p>An illustrated speculative fiction novel set in a climate-collapsed India, following a 14-year-old girl through AI, memory and resistance.</p><div class="tags"><span class="tag">Astro</span><span class="tag">fiction</span></div></div><span class="arrow">→</span></a>
       <a class="entry" data-s="stable" href="https://github.com/Varnasr/CandidateDossier"><span class="no"></span><div><h4>CandidateDossier</h4><span class="st"><i class="dot stable"></i>stable</span><span class="url">github.com/Varnasr/CandidateDossier</span></div><div><p>CSV to LaTeX to PDF generator for uniform, privacy-masked candidate dossiers. Runs via Netlify Functions or Overleaf.</p><div class="tags"><span class="tag">LaTeX</span><span class="tag">Netlify</span></div></div><span class="arrow">→</span></a>
       <a class="entry" data-s="proto" href="https://github.com/Varnasr/Experiments/tree/main/court-translator"><span class="no"></span><div><h4>Court Petition Translator</h4><span class="st"><i class="dot proto"></i>prototype</span><span class="url">github.com/Varnasr/Experiments/tree/main/court-translator</span></div><div><p>Hindi to English translation for Supreme Court and High Court petitions. Sarvam AI handles translation; Llama 3.3 corrects legal terminology.</p><div class="tags"><span class="tag">Sarvam AI</span><span class="tag">Groq</span></div></div><span class="arrow">→</span></a>
-      <a class="entry" data-s="active" data-live="1" href="https://varnasr-experiments.netlify.app/"><span class="no"></span><div><h4>Experiments</h4><span class="st"><i class="dot active"></i>active</span><span class="url">varnasr-experiments.netlify.app · github.com/Varnasr/Experiments</span></div><div><p>The sandbox the prototypes are built in: twenty small tools that run in the browser, from causal-inference estimators and poverty measures to legal calculators, each checked against something outside the page. Where ideas live before they graduate to their own repository or are retired.</p><div class="tags"><span class="tag">HTML</span><span class="tag">no dependencies</span></div></div><span class="arrow">→</span></a>
+      <a class="entry" data-s="active" data-live="1" href="https://varnasr-experiments.netlify.app/"><span class="no"></span><div><h4>Experiments</h4><span class="st"><i class="dot active"></i>active</span><span class="url">varnasr-experiments.netlify.app · github.com/Varnasr/Experiments</span></div><div><p>Twenty small tools that run in the browser: causal-inference estimators, poverty and inequality measures, survey checks, legal calculators and others, each with a note on how it was checked. New ideas start here and move to a repository of their own if they last.</p><div class="tags"><span class="tag">HTML</span><span class="tag">no dependencies</span></div></div><span class="arrow">→</span></a>
     </div>
   </div>
   <p class="empty" id="empty">Nothing in the index matches that. Clear the search or the filters.</p>
@@ -317,14 +317,14 @@
 
 <!-- Retired -->
 <section id="retired"><div class="wrap">
-  <div class="sec-head"><div class="n"><i></i>04</div><div><h2>Retired, and kept public</h2><p>Archived and read-only. Nothing has been deleted: the code stays public, forkable and citable.</p></div></div>
+  <div class="sec-head"><div class="n"><i></i>04</div><div><h2>Retired</h2><p>Archived and read-only. The code is still public and can be forked or cited.</p></div></div>
   <div class="retired">
     <div class="ret"><h4>RootStack</h4><p>SQLite and PostgreSQL schemas for the shared data layer.</p><span class="st"><i class="dot retired"></i>retired</span></div>
     <div class="ret"><h4>BridgeStack</h4><p>FastAPI backend serving RootStack to frontends.</p><span class="st"><i class="dot retired"></i>retired</span></div>
     <div class="ret"><h4>ViewStack</h4><p>React dashboard for exploring the data.</p><span class="st"><i class="dot retired"></i>retired</span></div>
   </div>
   <div class="notice">
-    <p>These three formed a database, API and dashboard pipeline. It was the most expensive part of this project to maintain and the least used, and the research toolkits never depended on it.</p>
+    <p>These three were a database, an API and a dashboard, built as one pipeline. It cost the most to maintain, was used the least, and the research toolkits never depended on it.</p>
     <p><strong>ImpactLex is not on this list.</strong> Its old repository is archived, but the project graduated into <a href="https://www.impactmojo.in/impactlex/">Impact Mojo</a> rather than winding down; it is listed under Teaching and practice above. An archived repository and a finished project are not the same thing.</p>
     <p>Four further stacks (ClimateStack, EduStack, SocialStack and InfraStack) sat on a published roadmap for a year without a line of code written. That roadmap has been withdrawn rather than left standing as a promise to readers. The needs behind it are better served by How India Lives, PolicyDhara and JanVayu.</p>
   </div>
@@ -332,36 +332,36 @@
 
 <!-- Who it is for -->
 <section id="for"><div class="wrap">
-  <div class="sec-head"><div class="n"><i></i>05</div><div><h2>Who this is for</h2><p>Development practitioners working across health, education, gender equity, climate and governance, mostly in India and South Asia.</p></div></div>
+  <div class="sec-head"><div class="n"><i></i>05</div><div><h2>Who this is for</h2><p>People working on health, education, gender, climate and governance, mostly in India and South Asia.</p></div></div>
   <div class="aud">
-    <div><h4>Practitioners</h4><p>Ready-to-use analysis tools for MEL, impact assessment and programme design.</p></div>
-    <div><h4>Researchers and evaluators</h4><p>Reproducible scripts, sample data and evaluation frameworks grounded in South Asian fieldwork.</p></div>
-    <div><h4>Analysts in NGOs</h4><p>Python, R and Stata templates that work with the data formats and analysis patterns in use in the sector.</p></div>
-    <div><h4>Students and teachers</h4><p>Practice datasets, guided notebooks, case studies and worked examples for development economics and public policy courses.</p></div>
+    <div><h4>Practitioners</h4><p>Analysis tools for monitoring and evaluation, impact assessment and programme design.</p></div>
+    <div><h4>Researchers and evaluators</h4><p>Scripts, sample data and evaluation frameworks from fieldwork in South Asia.</p></div>
+    <div><h4>Analysts in NGOs</h4><p>Python, R and Stata templates for the data formats the sector uses.</p></div>
+    <div><h4>Students and teachers</h4><p>Practice datasets, notebooks, case studies and worked examples for development economics and public policy courses.</p></div>
   </div>
 </div></section>
 
 <!-- About -->
 <section id="about"><div class="wrap">
-  <div class="sec-head"><div class="n"><i></i>06</div><div><h2>Who keeps it</h2></div></div>
+  <div class="sec-head"><div class="n"><i></i>06</div><div><h2>About</h2></div></div>
   <div class="about">
     <img src="photo.jpg" alt="Dr. Varna Sri Raman">
     <div>
       <h3>Dr. Varna Sri Raman</h3>
-      <p>Development economist, social researcher and licensed social justice worker with more than twenty years across public health, education, gender equity and climate resilience in India and South Asia.</p>
-      <p>Has led programme design, MEL strategies and research with Oxfam, UNICEF, the Gates Foundation, PLAN India and BBC Media Action. Founder of StoryWell Books.</p>
+      <p>Development economist, social researcher and licensed social justice worker. Twenty years of work on public health, education, gender and climate in India and South Asia.</p>
+      <p>Has led programme design, evaluation and research for Oxfam, UNICEF, the Gates Foundation, PLAN India and BBC Media Action. Founder of StoryWell Books.</p>
       <div class="links"><a href="https://github.com/Varnasr">github ↗</a><a href="https://x.com/varna">x.com ↗</a><a href="https://on-web.link/varna">web ↗</a></div>
     </div>
   </div>
-  <div class="support"><p>If this work is useful to you, you can support it directly.</p><a class="btn teal" href="support.html">Support via UPI</a></div>
+  <div class="support"><p>If this work is useful to you, you can support it by UPI.</p><a class="btn teal" href="support.html">Support via UPI</a></div>
 </div></section>
 
 <footer><div class="wrap">
   <div>
     <div class="fl"><a href="https://github.com/Varnasr/OpenStacks-for-Change">GitHub</a><a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/MAINTENANCE.md">Maintenance policy</a><a href="https://github.com/Varnasr/.github/blob/main/CONTRIBUTING.md">Contributing</a><a href="https://github.com/Varnasr/.github/blob/main/CODE_OF_CONDUCT.md">Code of conduct</a><a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/CITATION.cff">Cite this work</a></div>
-    <p class="note">AI tools were used for documentation and code generation support. All decisions, designs, datasets and content curation are the creator's.</p>
+    <p class="note">AI tools were used for documentation and code. The decisions, designs, datasets and selection of projects are the author's.</p>
   </div>
-  <div class="right"><p>MIT License. Built by <a href="https://github.com/Varnasr">Varna Sri Raman</a> in Delhi, India.</p><p class="note">Status labels last reviewed <span id="reviewed">August 2026</span>.</p></div>
+  <div class="right"><p>MIT License. Built by <a href="https://github.com/Varnasr">Varna Sri Raman</a> in Delhi, India.</p></div>
 </div></footer>
 
 <script>

--- a/support.html
+++ b/support.html
@@ -27,9 +27,9 @@
 </head>
 <body>
   <main>
-    <div class="k">Support this work</div>
-    <h1>Thank you for keeping it open</h1>
-    <p>Everything indexed on openstacks.dev is free to use. If it has been useful, you can contribute directly by UPI.</p>
+    <div class="k">openstacks.dev</div>
+    <h1>Support this work</h1>
+    <p>Everything on openstacks.dev is free to use. If it has been useful to you, you can send a contribution by UPI.</p>
     <p class="upi">varna@icici</p>
     <p>Or scan the code:</p>
     <img src="upi_qr_varna_icici.png" alt="UPI QR code for varna@icici">


### PR DESCRIPTION
## What does this PR do?

Rewrites the text on the redesigned landing page in plain language. Layout, entries and links are unchanged.

- Hero: the headline is now "Open-source work on development research, data and policy" with no italic emphasis word; the lede states the count, the grouping and where the labels are defined.
- Kicker "An index, not a product" becomes "Index of repositories"; the "finished face / workshop" line under Start here is gone.
- Section headings are literal (Start here, What this is, Repositories, Retired, Who this is for, About).
- The "What this is" prose states what happened to the eight stacks in numbers: five in use, three archived and named.
- The four label definitions are shortened to what each one commits the maintainer to.
- The footer's "Status labels last reviewed August 2026" line is removed, since that date was not verified against anything.
- The support page heading is now literal.

## Type of change

- [ ] Bug fix (broken link, layout, JS error)
- [ ] New content (course, case study, translation)
- [ ] New feature or tool
- [ ] Accessibility improvement
- [ ] Performance improvement
- [x] Documentation update

## Checklist

- [x] Tested on desktop browser (headless: counts, filters, search and empty state unchanged)
- [x] Tested on mobile browser
- [x] No console errors
- [x] Links are working (no hrefs changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fZcU8aMsZGyjn4Lmtxk9P

---
_Generated by [Claude Code](https://claude.ai/code/session_018fZcU8aMsZGyjn4Lmtxk9P)_