### PR TITLE
Fix: wordmark no longer stretched; fitted to width on phones and desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@500;700;800&family=Work+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,700;12..96,800&family=Work+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
     :root {
       --black: #0d0d0f; --white: #f6f2ea; --grey: #8a8a90; --grey-2: #2a2a2f;
       --navy: #14305c; --saffron: #f2a541; --teal: #0f6e56; --brick: #b23a2a; --ash: #d9d5cc;
-      --display: "Syne", "Arial Black", Impact, sans-serif;
+      --display: "Bricolage Grotesque", "Helvetica Neue", Arial, sans-serif;
       --sans: "Work Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
       --pad: clamp(1.1rem, 4vw, 3.5rem);
@@ -35,19 +35,19 @@
     /* top bar */
     .top { position: sticky; top: 0; z-index: 30; background: var(--black); border-bottom: 2px solid var(--white); }
     .top .in { display: flex; align-items: stretch; justify-content: space-between; height: 3.6rem; padding: 0 var(--pad); }
-    .brand { display: flex; align-items: center; gap: .7rem; font-family: var(--display); font-weight: 800; letter-spacing: .01em; font-size: 1.05rem; text-transform: uppercase; }
+    .brand { display: flex; align-items: center; gap: .6rem; font-family: var(--display); font-weight: 700; letter-spacing: 0; font-size: .9rem; text-transform: uppercase; white-space: nowrap; }
     .brand svg { width: 28px; height: 28px; }
     .top nav { display: flex; }
-    .top nav a { display: flex; align-items: center; padding: 0 1rem; font-family: var(--mono); font-size: .78rem; text-transform: uppercase; letter-spacing: .06em; border-left: 2px solid var(--white); }
+    .top nav a { display: flex; align-items: center; padding: 0 1rem; font-family: var(--mono); font-size: .78rem; text-transform: uppercase; letter-spacing: .06em; border-left: 2px solid var(--white); white-space: nowrap; }
     .top nav a:hover { background: var(--white); color: var(--black); }
-    @media (max-width: 760px) { .top nav a:not(.gh) { display: none; } }
+    @media (max-width: 760px) { .top nav a:not(.gh) { display: none; } .brand { font-size: .8rem; } .top nav a { padding: 0 .8rem; } }
 
     /* hero */
     .hero { padding: clamp(2.5rem, 7vw, 6rem) var(--pad) clamp(2rem, 5vw, 4rem); border-bottom: 2px solid var(--white); position: relative; overflow: hidden; }
     .hero .mark { position: absolute; right: var(--pad); top: 2.5rem; width: clamp(120px, 22vw, 320px); opacity: .95; }
     .hero .mark rect.o { animation: dash 24s linear infinite; }
     @keyframes dash { to { stroke-dashoffset: -400; } }
-    .word { font-family: var(--display); font-weight: 800; text-transform: uppercase; line-height: .86; letter-spacing: -.03em; font-size: clamp(3.4rem, 14vw, 13.5rem); }
+    .word { font-family: var(--display); font-weight: 800; text-transform: uppercase; line-height: .88; letter-spacing: -.035em; font-size: clamp(2.6rem, 13vw, 12rem); }
     .word span { display: block; }
     .word .s2 { color: var(--saffron); }
     .word .s3 { font-size: .38em; letter-spacing: 0; line-height: 1; margin-top: .35em; color: var(--white); font-weight: 700; }
@@ -65,7 +65,7 @@
     .btn:hover { background: var(--white); color: var(--black); }
     .btn.fill { background: var(--saffron); border-color: var(--saffron); color: var(--black); }
     .btn.fill:hover { background: var(--white); border-color: var(--white); }
-    @media (max-width: 860px) { .hero-grid { grid-template-columns: 1fr; margin-top: 2rem; } .counts { grid-template-columns: 1fr 1fr; } .counts div:nth-child(3) { border-left: none; } .counts div:nth-child(n+3) { border-top: 2px solid var(--white); } .hero .mark { top: 1.2rem; width: 96px; } }
+    @media (max-width: 860px) { .hero-grid { grid-template-columns: 1fr; margin-top: 2rem; } .counts { grid-template-columns: 1fr 1fr; } .counts div:nth-child(3) { border-left: none; } .counts div:nth-child(n+3) { border-top: 2px solid var(--white); } .hero .mark { position: static; display: block; width: 72px; margin: 0 0 1.4rem auto; } }
 
     /* search bar */
     .bar { position: sticky; top: 3.6rem; z-index: 25; background: var(--black); border-bottom: 2px solid var(--white); display: grid; grid-template-columns: 1fr auto; }
@@ -347,6 +347,16 @@
 <script>
 (function () {
   'use strict';
+  // fit the wordmark to the width it has, whatever the font's real width is
+  var word = document.querySelector('.word'), hero = document.querySelector('.hero'), mark = document.querySelector('.hero .mark');
+  function fit() {
+    var cs = getComputedStyle(hero), pad = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+    var wide = window.innerWidth > 860, avail = hero.clientWidth - pad - (wide ? mark.getBoundingClientRect().width + 32 : 0);
+    var fs = wide ? Math.min(192, window.innerWidth * 0.13) : window.innerWidth * 0.2; fs = Math.max(fs, 40); word.style.fontSize = fs + 'px';
+    var r = document.createRange(), span = word.querySelector('.s2');
+    for (var i = 0; i < 12; i++) { r.selectNodeContents(span); var w = r.getBoundingClientRect().width; if (w <= avail) break; fs = fs * (avail / w) * 0.985; word.style.fontSize = fs + 'px'; }
+  }
+  fit(); if (document.fonts && document.fonts.ready) document.fonts.ready.then(fit); window.addEventListener('resize', fit);
   var tiles = Array.prototype.slice.call(document.querySelectorAll('.tile'));
   var groups = Array.prototype.slice.call(document.querySelectorAll('.group'));
   tiles.forEach(function (t, i) { t.querySelector('.no').textContent = String(i + 1).padStart(3, '0'); });

--- a/support.html
+++ b/support.html
@@ -8,14 +8,14 @@
   <link rel="icon" type="image/png" href="favicon_openstacks.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@800&family=Work+Sans:wght@400;500&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,800&family=Work+Sans:wght@400;500&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
   <style>
     :root { --black:#0d0d0f; --white:#f6f2ea; --saffron:#f2a541; --grey:#8a8a90; }
     * { box-sizing:border-box; margin:0; padding:0; }
     body { font-family:"Work Sans",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; background:var(--black); color:var(--white); min-height:100vh; display:grid; place-items:center; padding:2rem 1.25rem; line-height:1.55; }
     main { border:2px solid var(--white); padding:2rem 2rem 1.8rem; max-width:28rem; width:100%; }
     .k { font-family:"JetBrains Mono",ui-monospace,monospace; font-size:.74rem; letter-spacing:.08em; text-transform:uppercase; color:var(--saffron); }
-    h1 { font-family:"Syne","Arial Black",sans-serif; font-weight:800; font-size:2.2rem; letter-spacing:-.02em; line-height:1; margin:.6rem 0 .9rem; text-transform:uppercase; }
+    h1 { font-family:"Bricolage Grotesque","Helvetica Neue",Arial,sans-serif; font-weight:800; font-size:2.2rem; letter-spacing:-.02em; line-height:1; margin:.6rem 0 .9rem; text-transform:uppercase; }
     p { color:#d8d3c8; font-size:.95rem; }
     .upi { font-family:"JetBrains Mono",ui-monospace,monospace; font-size:1.2rem; font-weight:500; color:var(--white); margin:1rem 0; letter-spacing:.02em; user-select:all; border:2px solid var(--saffron); display:inline-block; padding:.4rem .8rem; }
     img { width:220px; max-width:100%; height:auto; margin:.8rem 0 0; display:block; border:2px solid var(--white); }


### PR DESCRIPTION
## What does this PR do?

Syne 800 is an extended face, which is what made OPEN STACKS look pulled sideways at every width. The display face is now Bricolage Grotesque 800. The wordmark is sized by measuring STACKS against the available column after fonts load, so it fills the space without overflowing at 390px or 1280px. On phones the dashed mark sits inline above the wordmark instead of floating over it, and the brand and nav labels no longer wrap. The support page uses the same face.

## Type of change

- [x] Bug fix

## Checklist

- [x] Checked at 390px and 1280px in headless Chromium with the real font loaded: STACKS fits, no horizontal overflow, no console errors
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fZcU8aMsZGyjn4Lmtxk9P

---
_Generated by [Claude Code](https://claude.ai/code/session_018fZcU8aMsZGyjn4Lmtxk9P)_