### PR TITLE
Update: stop listing Experiments tools on this index

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,6 @@ Reusable scripts, notebooks, and templates for people doing MEL and applied rese
 
 InsightStack has a DOI: [10.5281/zenodo.15245182](https://doi.org/10.5281/zenodo.15245182).
 
-### Prototypes and research outputs
-
-Early-stage work, built in the [Experiments](https://github.com/Varnasr/Experiments) sandbox. Expect rough edges — these are shared because they are useful, not because they are finished.
-
-| Project | What it is |
-|---|---|
-| **[Court Petition Translator](https://github.com/Varnasr/Experiments/tree/main/court-translator)** | Hindi → English translation for Supreme Court and High Court petitions. Sarvam AI handles translation; Llama 3.3 corrects legal terminology (याचिकाकर्ता → Petitioner, अनुच्छेद → Article). Prototype. |
-
 ### Writing
 
 | Project | What it is |
@@ -97,7 +89,7 @@ Early-stage work, built in the [Experiments](https://github.com/Varnasr/Experime
 | Project | What it is |
 |---|---|
 | **[CandidateDossier](https://github.com/Varnasr/CandidateDossier)** | CSV → LaTeX → PDF generator for uniform, privacy-masked candidate dossiers. |
-| **[Experiments](https://github.com/Varnasr/Experiments)** | The sandbox the projects above are built in, plus smaller tools. Where ideas live before they graduate to their own repository — or get quietly retired. |
+| **[Experiments](https://github.com/Varnasr/Experiments)** | The sandbox. Small browser tools are built and indexed there and are not listed here; anything that lasts moves to a repository of its own and appears above. |
 | **[.github](https://github.com/Varnasr/.github)** | Shared community health files — contributing guide, code of conduct, issue templates — inherited by every repo above. |
 
 ---

--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
   <h1 class="word"><span class="s1">Open</span><span class="s2">Stacks</span><span class="s3">for Change</span></h1>
   <div class="hero-grid">
     <div>
-      <p>An index of open-source work on development research, data and policy. Twenty-six public repositories by Varna Sri Raman, most of them about India, grouped by what they are for. Each one has a status label; the labels are defined below and in the <a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/MAINTENANCE.md">maintenance policy</a>.</p>
+      <p>An index of open-source work on development research, data and policy. Twenty-five public repositories by Varna Sri Raman, most of them about India, grouped by what they are for. Each one has a status label; the labels are defined below and in the <a href="https://github.com/Varnasr/OpenStacks-for-Change/blob/main/MAINTENANCE.md">maintenance policy</a>.</p>
       <div class="cta"><a class="btn fill" href="#data">See the repositories</a><a class="btn" href="#start">Reader-facing sites</a></div>
     </div>
     <div class="counts" aria-label="Counts on this page">
@@ -209,7 +209,7 @@
 
 <div class="bar" id="bar">
   <input type="search" id="q" placeholder="Search the repositories" aria-label="Search the repositories">
-  <div class="st" role="group" aria-label="Filter by status"><button class="on" data-s="">All</button><button data-s="active">Active</button><button data-s="stable">Stable</button><button data-s="proto">Prototype</button><span class="cnt" id="count"></span></div>
+  <div class="st" role="group" aria-label="Filter by status"><button class="on" data-s="">All</button><button data-s="active">Active</button><button data-s="stable">Stable</button><span class="cnt" id="count"></span></div>
 </div>
 
 <!-- Start here -->
@@ -234,7 +234,7 @@
     <div class="legend" role="list">
       <div role="listitem"><b><i></i>Active</b><p>Being worked on. Issues and pull requests get a reply within days.</p></div>
       <div role="listitem"><b class="stable"><i></i>Stable</b><p>Works as described and is not being developed. Bug reports are welcome and may wait weeks for a reply. New features are unlikely.</p></div>
-      <div role="listitem"><b class="proto"><i></i>Prototype</b><p>Unfinished, and shared as it is. Lives in the Experiments repository until it gets a repository of its own or is dropped.</p></div>
+      <div role="listitem"><b class="proto"><i></i>Prototype</b><p>Unfinished, and shared as it is. Prototypes are not indexed here; they stay in the Experiments sandbox until they get a repository of their own or are dropped.</p></div>
       <div role="listitem"><b class="retired"><i></i>Retired</b><p>Archived on GitHub and read-only. Kept public so that links, citations and forks continue to work.</p></div>
     </div>
   </div>
@@ -289,8 +289,7 @@
     <a class="tile" data-s="active" href="https://github.com/Varnasr/the-measurement-trap"><span class="meta"><span class="stt active"><i></i>active</span><span class="no"></span></span><h3>The Measurement Trap</h3><p>Companion site for the forthcoming Routledge book on India's quest for social progress through eight decades of measurement.</p><span class="foot"><span class="url">github.com/Varnasr/the-measurement-trap</span><span class="tags"><span>HTML</span></span></span></a>
     <a class="tile" data-s="active" data-live="1" href="https://postheroic.world"><span class="meta"><span class="stt active"><i></i>active</span><span class="no"></span></span><h3>The Very Last Superhero</h3><p>An illustrated speculative fiction novel set in a climate-collapsed India, following a 14-year-old girl through AI, memory and resistance.</p><span class="foot"><span class="url">postheroic.world</span><span class="tags"><span>Astro</span><span>fiction</span></span></span></a>
     <a class="tile" data-s="stable" href="https://github.com/Varnasr/CandidateDossier"><span class="meta"><span class="stt stable"><i></i>stable</span><span class="no"></span></span><h3>CandidateDossier</h3><p>CSV to LaTeX to PDF generator for uniform, privacy-masked candidate dossiers. Runs via Netlify Functions or Overleaf.</p><span class="foot"><span class="url">github.com/Varnasr/CandidateDossier</span><span class="tags"><span>LaTeX</span><span>Netlify</span></span></span></a>
-    <a class="tile" data-s="proto" href="https://github.com/Varnasr/Experiments/tree/main/court-translator"><span class="meta"><span class="stt proto"><i></i>prototype</span><span class="no"></span></span><h3>Court Petition Translator</h3><p>Hindi to English translation for Supreme Court and High Court petitions. Sarvam AI handles translation; Llama 3.3 corrects legal terminology.</p><span class="foot"><span class="url">github.com/Varnasr/Experiments/tree/main/court-translator</span><span class="tags"><span>Sarvam AI</span><span>Groq</span></span></span></a>
-    <a class="tile big" data-s="active" data-live="1" href="https://varnasr-experiments.netlify.app/"><span class="meta"><span class="stt active"><i></i>active</span><span class="no"></span></span><h3>Experiments</h3><p>Twenty small tools that run in the browser: causal-inference estimators, poverty and inequality measures, survey checks, legal calculators and others, each with a note on how it was checked. New ideas start here and move to a repository of their own if they last.</p><span class="foot"><span class="url">varnasr-experiments.netlify.app · github.com/Varnasr/Experiments</span><span class="tags"><span>HTML</span><span>no dependencies</span></span></span></a>
+    <a class="tile big" data-s="active" data-live="1" href="https://varnasr-experiments.netlify.app/"><span class="meta"><span class="stt active"><i></i>active</span><span class="no"></span></span><h3>Experiments</h3><p>The sandbox. Small browser tools are built and indexed there, and are not listed here; anything that lasts moves to a repository of its own and appears on this page.</p><span class="foot"><span class="url">varnasr-experiments.netlify.app · github.com/Varnasr/Experiments</span><span class="tags"><span>HTML</span><span>no dependencies</span></span></span></a>
   </div>
 </section>
 


### PR DESCRIPTION
## What does this PR do?

Keeps the two indexes apart. The Court Petition Translator lives in the Experiments sandbox, so its tile and its README row are removed. The Experiments tile becomes a plain pointer to the sandbox instead of summarising what is in it. With no prototype tiles left, the Prototype filter button goes and the label definition states the policy: prototypes are not indexed here. The hero count is corrected to twenty-five repositories; the stat tiles are computed from the tiles and now read 25.

## Type of change

- [x] Content update

## Checklist

- [x] Headless check: 25 tiles, counts 25 / 14 live / 15 active / 10 stable, no link to court-translator, stable filter reads "10 of 25", no console errors
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fZcU8aMsZGyjn4Lmtxk9P

---
_Generated by [Claude Code](https://claude.ai/code/session_018fZcU8aMsZGyjn4Lmtxk9P)_